### PR TITLE
add google tts for all voice families

### DIFF
--- a/podcastfy/client.py
+++ b/podcastfy/client.py
@@ -94,7 +94,8 @@ def process_content(
         if generate_audio:
             api_key = None
             # edge does not require an API key
-            if tts_model != "edge":
+            # google requires application credentials file
+            if tts_model not in ("edge", "google"):
                 api_key = getattr(config, f"{tts_model.upper()}_API_KEY")
 
             text_to_speech = TextToSpeech(model=tts_model, api_key=api_key)
@@ -128,7 +129,7 @@ def main(
         None,
         "--tts-model",
         "-tts",
-        help="TTS model to use (openai, elevenlabs or edge)",
+        help="TTS model to use (openai, elevenlabs, google or edge)",
     ),
     transcript_only: bool = typer.Option(
         False, "--transcript-only", help="Generate only a transcript without audio"

--- a/podcastfy/conversation_config.yaml
+++ b/podcastfy/conversation_config.yaml
@@ -35,6 +35,17 @@ text_to_speech:
     default_voices:
       question: "en-US-JennyNeural"
       answer: "en-US-EricNeural"
+  google:
+    default_voices:
+      # REF: https://cloud.google.com/text-to-speech/docs/voices
+      question:
+        voice: "en-US-Journey-F"
+        #rate: 1.1 # not supported in Journey voices
+        #pitch: -2 # not supported in Journey voices
+      answer:
+        voice: "en-US-Journey-D"
+        #rate: 1.1 # not supported in Journey voices
+        #pitch: 0 # not supported in Journey voices
   audio_format: "mp3"
   temp_audio_dir: "data/audio/tmp/"
   ending_message: "Bye Bye!"


### PR DESCRIPTION
I've added the support for google's tts voices (tested: studio, journey, wavenet, neural, standard).
The new method also shows how to render each speaker as a separate audio track and how to combine both tracks into a single output. The tracks are also saved separately to facilitate workflows with animating AI avatars.

I haven't touched pyproject.toml (or requirements.txt) as poetry had issues with pyprojects.
Please feel free to adjust the code as you wish to merge it as in next few days I might have less time for FOSS projects.