### PR TITLE
docs: highlight callouts

### DIFF
--- a/docs/source/usage/config.md
+++ b/docs/source/usage/config.md
@@ -14,11 +14,14 @@ The project uses a combination of a `.env` file for managing API keys and sensit
    OPENAI_API_KEY=your_openai_api_key_here
    ```
 API Key Requirements:
-- JINA_API_KEY: Required only for parsing website content as input. (get your [free API key](https://jina.ai/reader/#apiform))
-- GEMINI_API_KEY: Mandatory for all operations. (get your [free API key](aistudio.google.com/app/apikey))
-- OPENAI_API_KEY or ELEVENLABS_API_KEY: Required for audio generation (paid service). Edge TTS can be also used for audio generation without an API key.
+- `JINA_API_KEY`: Required only for parsing website content as input. (get your [free API key](https://jina.ai/reader/#apiform))
+- `GEMINI_API_KEY`: Mandatory for all operations. (get your [free API key](aistudio.google.com/app/apikey))
+- `OPENAI_API_KEY` or `ELEVENLABS_API_KEY`: Required for audio generation (paid service). `Edge TTS` can be also used for audio generation without an API key.
 
-Ensure you have the necessary API keys based on your intended usage of Podcastfy. Note: Never share your `.env` file or commit it to version control. It contains sensitive information that should be kept private. The `config.yaml` file can be shared and version-controlled as it doesn't contain sensitive data.
+Ensure you have the necessary API keys based on your intended usage of Podcastfy.
+
+> [!Note]
+> Never share your `.env` file or commit it to version control. It contains sensitive information that should be kept private. The `config.yaml` file can be shared and version-controlled as it doesn't contain sensitive data.
 
 ## Conversation Configuration
 

--- a/usage/cli.md
+++ b/usage/cli.md
@@ -52,13 +52,13 @@ Please make sure you follow configuration instructions first - [See Setup](READM
    ```
    python -m podcastfy.client --url https://example.com/article1 --transcript-only --local
    ```
+
 For more information on available options, use:
    ```
    python -m podcastfy.client --help
+   ```
 
 11. Generate a podcast from raw text input:
    ```
    python -m podcastfy.client --text "Your raw text content here that you want to convert into a podcast"
-   ```
-
    ```

--- a/usage/config.md
+++ b/usage/config.md
@@ -13,10 +13,13 @@ The project uses a combination of a `.env` file for managing API keys and sensit
    OPENAI_API_KEY=your_openai_api_key_here
    ```
 API Key Requirements:
-- GEMINI_API_KEY: Required for transcript generation if not using a [local llm](local_llm.md). (get your [free API key](aistudio.google.com/app/apikey))
-- OPENAI_API_KEY or ELEVENLABS_API_KEY: Required for audio generation if not using Microsoft Edge TTS `tts_model=edge`.
+- `GEMINI_API_KEY`: Required for transcript generation if not using a [local llm](local_llm.md). (get your [free API key](aistudio.google.com/app/apikey))
+- `OPENAI_API_KEY` or `ELEVENLABS_API_KEY`: Required for audio generation if not using Microsoft Edge TTS `tts_model=edge`.
 
-Ensure you have the necessary API keys based on your intended usage of Podcastfy. Note: Never share your `.env` file or commit it to version control. It contains sensitive information that should be kept private. The `config.yaml` file can be shared and version-controlled as it doesn't contain sensitive data.
+Ensure you have the necessary API keys based on your intended usage of Podcastfy.
+
+> [!Note]
+> Never share your `.env` file or commit it to version control. It contains sensitive information that should be kept private. The `config.yaml` file can be shared and version-controlled as it doesn't contain sensitive data.
 
 ## Example Configurations
 


### PR DESCRIPTION
This adds GFM callout to improve readability of the documentation.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/721e23b4-e619-4026-9c03-3f0e8c32c486) | ![image](https://github.com/user-attachments/assets/a860c470-92d0-402f-9e94-fe31b311124e) |
| ![image](https://github.com/user-attachments/assets/19287169-a9a8-4008-91af-d2df59a23083) | ![image](https://github.com/user-attachments/assets/0d117784-7642-41f5-95e9-9fa1d43bfd7b) |
