### PR TITLE
Refactor generate_podcast function to reduce complexity

### DIFF
--- a/podcastfy/client.py
+++ b/podcastfy/client.py
@@ -261,7 +261,7 @@ def generate_content_from_sources(urls, url_file, image_paths, text):
 
 
 def handle_transcript_generation(
-    transcript_file, tts_model, transcript_only, config, conversation_config, is_local, text
+    transcript_file, tts_model, transcript_only, config, conversation_config, is_local, text, image_paths
 ):
     """Generate and process transcript files."""
     if image_paths:
@@ -305,7 +305,7 @@ def generate_podcast(
 
         if transcript_file:
             return handle_transcript_generation(
-                transcript_file, tts_model, transcript_only, config, conversation_config, is_local, text
+                transcript_file, tts_model, transcript_only, config, conversation_config, is_local, text, image_paths
             )
         
         urls_list, image_paths, text = generate_content_from_sources(urls, url_file, image_paths, text)


### PR DESCRIPTION
- Split `generate_podcast` into smaller helper functions: `load_default_configuration`, `get_conversation_config`, `generate_content_from_sources`, and `handle_transcript_generation`.
- Each helper function now handles a single responsibility, making `generate_podcast` more concise and easier to maintain.
- This refactor enhances readability, reduces code duplication, and isolates key processes for improved debugging and testing.