### PR TITLE
Add support for optional LLM model parameter in content processing

### DIFF
--- a/podcastfy/client.py
+++ b/podcastfy/client.py
@@ -16,6 +16,7 @@ from podcastfy.text_to_speech import TextToSpeech
 from podcastfy.utils.config import Config, load_config
 from podcastfy.utils.config_conversation import load_conversation_config
 from podcastfy.utils.logger import setup_logger
+from langchain_core.language_models.base import BaseLanguageModel
 from typing import List, Optional, Dict, Any
 import copy
 
@@ -51,6 +52,7 @@ def process_content(
     text: Optional[str] = None,
     model_name: Optional[str] = None,
     api_key_label: Optional[str] = None,
+    llm_model: Optional[BaseLanguageModel] = None,
     topic: Optional[str] = None,
     longform: bool = False
 ):
@@ -85,7 +87,8 @@ def process_content(
                 is_local=is_local,
                 model_name=model_name,
                 api_key_label=api_key_label,
-                conversation_config=conv_config.to_dict()
+                conversation_config=conv_config.to_dict(),
+                llm_model=llm_model
             )
 
             combined_content = ""
@@ -287,8 +290,9 @@ def generate_podcast(
     text: Optional[str] = None,
     llm_model_name: Optional[str] = None,
     api_key_label: Optional[str] = None,
+    llm_model: Optional[BaseLanguageModel] = None,
     topic: Optional[str] = None,
-    longform: bool = False,
+    longform: bool = False
 ) -> Optional[str]:
     """
     Generate a podcast or transcript from a list of URLs, a file containing URLs, a transcript file, or image files.
@@ -354,6 +358,7 @@ def generate_podcast(
                 text=text,
                 model_name=llm_model_name,
                 api_key_label=api_key_label,
+                llm_model=llm_model,
                 topic=topic,
                 longform=longform
             )
@@ -380,6 +385,7 @@ def generate_podcast(
                 text=text,
                 model_name=llm_model_name,
                 api_key_label=api_key_label,
+                llm_model=llm_model,
                 topic=topic,
                 longform=longform
             )

--- a/podcastfy/content_generator.py
+++ b/podcastfy/content_generator.py
@@ -23,6 +23,8 @@ import logging
 from langchain.prompts import HumanMessagePromptTemplate
 from abc import ABC, abstractmethod
 
+from langchain_core.language_models.base import BaseLanguageModel
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,6 +36,7 @@ class LLMBackend:
         max_output_tokens: int,
         model_name: str,
         api_key_label: str = "GEMINI_API_KEY",
+        llm_model: Optional[BaseLanguageModel] = None
     ):
         """
         Initialize the LLMBackend.
@@ -56,7 +59,9 @@ class LLMBackend:
             "frequency_penalty": 0.75,  # Avoid repetition
         }
 
-        if is_local:
+        if llm_model:
+            self.llm = llm_model
+        elif is_local:
             self.llm = Llamafile() # replace with ollama
         elif (
             "gemini" in self.model_name.lower()
@@ -708,7 +713,8 @@ class ContentGenerator:
         is_local: bool=False, 
         model_name: str="gemini-1.5-pro-latest", 
         api_key_label: str="GEMINI_API_KEY",
-        conversation_config: Optional[Dict[str, Any]] = None
+        conversation_config: Optional[Dict[str, Any]] = None,
+        llm_model: Optional[BaseLanguageModel] = None,
     ):
         """
         Initialize the ContentGenerator.
@@ -749,6 +755,7 @@ class ContentGenerator:
             ),
             model_name=model_name,
             api_key_label=api_key_label,
+            llm_model=llm_model
         )
 
         self.llm = llm_backend.llm


### PR DESCRIPTION
Instead of defining and being limited to the models supported in the library via
- llm_model_name: str
- api_key_label: str
parameters.

I have added the option to add an llm_model (a langchain BaseLanguageModel object)
This gives the user the options to use any provider (supported by Langchain) without making changes in the podcastfy library

So instead of this
```python
audio_file = generate_podcast(
    urls=["https://en.wikipedia.org/wiki/Artificial_intelligence"],
    llm_model_name="gpt-4-turbo",
    api_key_label="OPENAI_API_KEY"
)
```


The user can now do this:
```python
# Define a llm
from langchain_openai.chat_models import AzureChatOpenAI
llm_model = AzureChatOpenAI(model="gpt-4.1")

# Use the model
audio_file = generate_podcast(
    urls=["https://en.wikipedia.org/wiki/Artificial_intelligence"],
    llm_model=llm_model
)
```