### PR TITLE
Fix: Unicode Error while writing transcription generated by model

### DIFF
--- a/podcastfy/content_generator.py
+++ b/podcastfy/content_generator.py
@@ -899,7 +899,7 @@ class ContentGenerator:
 
             # Save output if requested
             if output_filepath:
-                with open(output_filepath, "w") as file:
+                with open(output_filepath, "w",encoding='utf-8') as file:
                     file.write(self.response)
                 logger.info(f"Response content saved to {output_filepath}")
                 print(f"Transcript saved to {output_filepath}")


### PR DESCRIPTION
The ```generate_qa_content``` function occasionally fails to write transcriptions due to Unicode errors, especially when longform=True. Asking the LLM to generate UTF-8-compliant text reduced errors but didn’t eliminate them.