### PR TITLE
Fix setup link in CLI usage guide (Closes #279)

### DIFF
--- a/usage/cli.md
+++ b/usage/cli.md
@@ -1,7 +1,7 @@
 ## CLI
 
 Podcastfy can be used as a command-line interface (CLI) tool. See below some usage examples.
-Please make sure you follow configuration instructions first - [See Setup](README.md#setup).
+Please make sure you follow configuration instructions first - [See Setup](../README.md#setup).
 
 1. Generate a podcast from URLs (using OpenAI TTS by default):
    ```


### PR DESCRIPTION
### Fix: Setup Link in CLI Usage Guide

- Updated the setup link in `usage/cli.md` to point to the correct README location (`../README.md#setup`).
- Ensures users are directed to the main setup instructions.

Closes #279