### PR TITLE
Remove `base_dir` usage for `temp_audio_dir` to fix incorrect temp file location

### DIFF
--- a/podcastfy/text_to_speech.py
+++ b/podcastfy/text_to_speech.py
@@ -225,8 +225,6 @@ class TextToSpeech:
         self.output_directories = self.tts_config.get("output_directories", {})
         temp_dir = self.tts_config.get("temp_audio_dir", "data/audio/tmp/").rstrip("/").split("/")
         self.temp_audio_dir = os.path.join(*temp_dir)
-        base_dir = os.path.abspath(os.path.dirname(__file__))
-        self.temp_audio_dir = os.path.join(base_dir, self.temp_audio_dir)
 
         os.makedirs(self.temp_audio_dir, exist_ok=True)
 


### PR DESCRIPTION
**Description**:
Previously, `base_dir = os.path.abspath(os.path.dirname(__file__))` was joined with `temp_audio_dir`, causing temporary files to be created inside the installed library package:

```python
self.temp_audio_dir = os.path.join(base_dir, self.temp_audio_dir)
```

This problem appears when the project is installed via **pip** (and lives under `site-packages`), since temporary files are then placed inside the library package directory instead of an external temp directory.

This led to two issues:

1. Temporary files could not be deleted properly since they were stored inside the package directory.
2. The `temp_audio_dir:` setting in `conversation_config.yaml` was misleading, because the code automatically prefixed it with `base_dir`, making the actual storage location different from what was configured.

This PR removes the `base_dir` usage so that `temp_audio_dir` correctly reflects the path defined in `conversation_config.yaml` and ensures temporary files are placed in the intended external directory.

**Impact**:

* Temporary files are now created in the correct location
* `conversation_config.yaml` behaves as expected
* Fixes cleanup issues for temporary audio files when the project is installed via pip