### PR TITLE
feat: add 60db TTS provider

### DIFF
--- a/podcastfy/conversation_config.yaml
+++ b/podcastfy/conversation_config.yaml
@@ -49,6 +49,13 @@ text_to_speech:
       question: "R"
       answer: "S"
       model: "en-US-Studio-MultiSpeaker"
+  sixtydb:
+    default_voices:
+      # Documented default voices from https://docs.60db.ai/api-reference/voices/get-voices
+      # Replace with voice_ids from your 60db account for English / other languages.
+      question: "fbb75ed2-975a-40c7-9e06-38e30524a9a1"  # Zara
+      answer: "84982e79-c596-4883-b6fa-9af334767aef"   # Simmi
+    model: "60db-quality-v01"
   audio_format: "mp3"
   temp_audio_dir: "data/audio/tmp/"
   ending_message: "See You Next Time!"

--- a/podcastfy/tts/factory.py
+++ b/podcastfy/tts/factory.py
@@ -7,15 +7,17 @@ from .providers.openai import OpenAITTS
 from .providers.edge import EdgeTTS
 from .providers.gemini import GeminiTTS
 from .providers.geminimulti import GeminiMultiTTS
+from .providers.sixtydb import SixtyDbTTS
 class TTSProviderFactory:
     """Factory class for creating TTS providers."""
-    
+
     _providers: Dict[str, Type[TTSProvider]] = {
         'elevenlabs': ElevenLabsTTS,
         'openai': OpenAITTS,
         'edge': EdgeTTS,
         'gemini': GeminiTTS,
-        'geminimulti': GeminiMultiTTS
+        'geminimulti': GeminiMultiTTS,
+        'sixtydb': SixtyDbTTS
     }
     
     @classmethod

--- a/podcastfy/tts/providers/sixtydb.py
+++ b/podcastfy/tts/providers/sixtydb.py
@@ -1,0 +1,112 @@
+"""60db (api.60db.ai) TTS provider implementation."""
+
+import base64
+import requests
+
+from ..base import TTSProvider
+from typing import List
+
+
+class SixtyDbTTS(TTSProvider):
+    """
+    Text-to-Speech provider for 60db (https://60db.ai).
+
+    Calls POST https://api.60db.ai/tts-synthesize and decodes the
+    base64-wrapped audio payload into raw bytes so the rest of the
+    podcastfy pipeline (pydub merge) treats the output identically
+    to ElevenLabs / OpenAI providers.
+    """
+
+    API_URL = "https://api.60db.ai/tts-synthesize"
+
+    # 60db caps a single synthesis request at this many characters.
+    # Longer text must be chunked by the caller; we just guard here.
+    MAX_TEXT_LENGTH = 5000
+
+    def __init__(self, api_key: str = None, model: str = "60db-quality-v01"):
+        """
+        Initialize 60db TTS provider.
+
+        Args:
+            api_key (str): 60db API key (Bearer token from app.60db.ai
+                → Settings → Developer → API Keys). Read from
+                SIXTYDB_API_KEY env var if not supplied.
+            model (str): Reserved for interface compatibility. 60db
+                infers the active model from the voice_id, so this
+                value is stored but not transmitted.
+        """
+        self.api_key = api_key
+        self.model = model
+
+    def generate_audio(
+        self,
+        text: str,
+        voice: str,
+        model: str,
+        voice2: str = None,
+    ) -> bytes:
+        """
+        Synthesize speech via the 60db REST API.
+
+        Args:
+            text: text to synthesize (<=5000 chars per 60db limit)
+            voice: voice_id (UUID) or voice name configured in YAML
+            model: ignored by this provider (see __init__ docstring)
+            voice2: unused (single-speaker provider)
+
+        Returns:
+            Raw audio bytes in MP3 format.
+
+        Raises:
+            ValueError: empty/oversized text, missing voice, or missing API key.
+            RuntimeError: 60db responded with success=false or unexpected payload.
+            requests.HTTPError: non-2xx HTTP status from the 60db API.
+        """
+        self.validate_parameters(text, voice, model)
+        if not self.api_key:
+            raise ValueError(
+                "60db API key missing. Set SIXTYDB_API_KEY or pass api_key explicitly."
+            )
+        if len(text) > self.MAX_TEXT_LENGTH:
+            raise ValueError(
+                f"Text exceeds 60db {self.MAX_TEXT_LENGTH}-char limit ({len(text)} given)."
+            )
+
+        # The 60db endpoint accepts either `voice_id` (UUID) or `voice` (name).
+        # Treat anything with the canonical UUID dash pattern as a voice_id,
+        # everything else as a friendly voice name.
+        is_uuid_like = len(voice) == 36 and voice.count("-") == 4
+        voice_field = "voice_id" if is_uuid_like else "voice"
+
+        payload = {
+            "text": text,
+            voice_field: voice,
+            "output_format": "mp3",
+            "enhance": True,
+        }
+
+        response = requests.post(
+            self.API_URL,
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=60,
+        )
+        response.raise_for_status()
+
+        body = response.json()
+        if not body.get("success") or "audio_base64" not in body:
+            raise RuntimeError(
+                f"60db TTS failed: {body.get('message', 'unknown error')}"
+            )
+
+        return base64.b64decode(body["audio_base64"])
+
+    def get_supported_tags(self) -> List[str]:
+        """
+        Supported SSML tags. 60db docs do not enumerate SSML support, so we
+        expose the conservative subset that ElevenLabs / common engines accept.
+        """
+        return ['lang', 'p', 's', 'sub']

--- a/podcastfy/utils/config.py
+++ b/podcastfy/utils/config.py
@@ -56,7 +56,8 @@ class Config:
 		self.GEMINI_API_KEY: str = os.getenv("GEMINI_API_KEY", "")
 		self.OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
 		self.ELEVENLABS_API_KEY: str = os.getenv("ELEVENLABS_API_KEY", "")
-		
+		self.SIXTYDB_API_KEY: str = os.getenv("SIXTYDB_API_KEY", "")
+
 		config_path = get_config_path(config_file)
 		if config_path:
 			with open(config_path, 'r') as file:
@@ -88,7 +89,7 @@ class Config:
 		for key, value in kwargs.items():
 			if key in self.config:
 				self.config[key] = value
-			elif key in ['JINA_API_KEY', 'GEMINI_API_KEY', 'OPENAI_API_KEY', 'ELEVENLABS_API_KEY']:
+			elif key in ['JINA_API_KEY', 'GEMINI_API_KEY', 'OPENAI_API_KEY', 'ELEVENLABS_API_KEY', 'SIXTYDB_API_KEY']:
 				setattr(self, key, value)
 			else:
 				raise ValueError(f"Unknown configuration key: {key}")
@@ -131,10 +132,11 @@ def main() -> None:
 	print(f"GEMINI_API_KEY: {'Set' if config.GEMINI_API_KEY else 'Not set'}")
 	print(f"OPENAI_API_KEY: {'Set' if config.OPENAI_API_KEY else 'Not set'}")
 	print(f"ELEVENLABS_API_KEY: {'Set' if config.ELEVENLABS_API_KEY else 'Not set'}")
+	print(f"SIXTYDB_API_KEY: {'Set' if config.SIXTYDB_API_KEY else 'Not set'}")
 
 	# Print a warning for any missing configuration
 	missing_config = []
-	for key in ['JINA_API_KEY', 'GEMINI_API_KEY', 'OPENAI_API_KEY', 'ELEVENLABS_API_KEY']:
+	for key in ['JINA_API_KEY', 'GEMINI_API_KEY', 'OPENAI_API_KEY', 'ELEVENLABS_API_KEY', 'SIXTYDB_API_KEY']:
 		if not getattr(config, key):
 			missing_config.append(key)
 


### PR DESCRIPTION
Adds SixtyDbTTS provider that calls POST https://api.60db.ai/tts-synthesize, decoding the base64-wrapped JSON audio response into raw bytes so the existing pydub merge pipeline treats it the same as ElevenLabs/OpenAI output.

Changes:
- podcastfy/tts/providers/sixtydb.py: new provider, mirrors ElevenLabsTTS shape; supports voice_id (UUID) or voice (name) via heuristic; 5000-char guard per 60db API limit; Bearer auth.
- podcastfy/tts/factory.py: register 'sixtydb' -> SixtyDbTTS.
- podcastfy/utils/config.py: SIXTYDB_API_KEY env-var loading + whitelist
  + missing-config warning.
- podcastfy/conversation_config.yaml: sixtydb section with documented default voices (Zara, Simmi) and default model 60db-quality-v01.

Usage:
  export SIXTYDB_API_KEY=... TextToSpeech(model='sixtydb').convert_to_speech(transcript, 'out.mp3')